### PR TITLE
Update timestamp format to Spark 3

### DIFF
--- a/src/getting-started/apache-spark/dataframe-and-dataset.md
+++ b/src/getting-started/apache-spark/dataframe-and-dataset.md
@@ -97,7 +97,7 @@ scala> :paste
 // Entering paste mode (ctrl-D to finish)
 val df = spark.read
               .schema(schema)
-              .option("timestampFormat", "MM/dd/yy:hh:mm")
+              .option("timestampFormat", "M/d/y:h:m")
               .csv("./sensordata.csv")
 // Exiting paste mode, now interpreting.
 df: org.apache.spark.sql.DataFrame =
@@ -243,7 +243,7 @@ scala> :paste
 
 val ds = spark.read
               .schema(schema)
-              .option("timestampFormat", "MM/dd/yy:hh:mm")
+              .option("timestampFormat", "M/d/y:h:m")
               .csv("./sensordata.csv")
               .as[SensorData]
 

--- a/src/getting-started/apache-spark/packaging-your-application-using-sbt.md
+++ b/src/getting-started/apache-spark/packaging-your-application-using-sbt.md
@@ -196,7 +196,7 @@ object ExampleSpark {
 
     val ds = spark.read
                   .schema(schema)
-                  .option("timestampFormat", "MM/dd/yy:hh:mm")
+                  .option("timestampFormat", "M/d/y:h:m")
                   .csv("./sensordata.csv")
                   .as[SensorData]
 


### PR DESCRIPTION
Fixes:
```
org.apache.spark.SparkUpgradeException: You may get a different result due to the upgrading of Spark 3.0: Fail to parse '3/10/14:1:01' in the new parser. You can set spark.sql.legacy.timeParserPolicy to LEGACY to restore the behavior before Spark 3.0, or set to CORRECTED and treat it as an invalid datetime string.
```

bors r+