### PR TITLE
Add double quotes to docker command - alos.md

### DIFF
--- a/src/getting-started/alos.md
+++ b/src/getting-started/alos.md
@@ -30,7 +30,7 @@ docker build -t aw3d30 https://github.com/mbrobbel/aw3d30-parquet.git#main
 Once you've build the image, you can run it as follows:
 
 ```
-docker run -it --rm -v `pwd`:/io aw3d30 -t /io/tif -p /io/parquet <set>
+docker run -it --rm -v "`pwd`":/io aw3d30 -t /io/tif -p /io/parquet <set>
 ```
 
 Or when built from source:


### PR DESCRIPTION
Fix missing double quotes in docker command for the ALOS instructions